### PR TITLE
Implement handling of `bids_id` column

### DIFF
--- a/proc_dash/app.py
+++ b/proc_dash/app.py
@@ -183,7 +183,8 @@ def process_bagel(contents, filename):
         data, total_subjects, sessions, upload_error = util.parse_csv_contents(
             contents=contents, filename=filename
         )
-    except Exception:
+    except Exception as exc:
+        print(exc)  # for debugging
         upload_error = "Something went wrong while processing this file."
 
     if upload_error is not None:

--- a/proc_dash/plotting.py
+++ b/proc_dash/plotting.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import plotly.express as px
 
+import proc_dash.utility as util
+
 STATUS_CMAP = px.colors.qualitative.Bold
 STATUS_COLORS = {
     "SUCCESS": STATUS_CMAP[5],
@@ -23,7 +25,7 @@ LAYOUTS = {
 def transform_data_to_long(data: pd.DataFrame) -> pd.DataFrame:
     return pd.melt(
         data,
-        id_vars=["participant_id", "session"],
+        id_vars=util.get_id_columns(data),
         var_name="pipeline_name",
         value_name="pipeline_complete",
     )

--- a/proc_dash/utility.py
+++ b/proc_dash/utility.py
@@ -65,13 +65,21 @@ def extract_pipelines(bagel: pd.DataFrame) -> dict:
     return pipelines_dict
 
 
+def get_id_columns(data: pd.DataFrame) -> list:
+    """Returns names of columns which identify a given participant record"""
+    return (
+        ["participant_id", "bids_id", "session"]
+        if "bids_id" in data.columns
+        else ["participant_id", "session"]
+    )
+
+
 def are_subjects_same_across_pipelines(bagel: pd.DataFrame) -> bool:
     """Checks if subjects and sessions are the same across pipelines in the input."""
     pipelines_dict = extract_pipelines(bagel)
 
     pipeline_subject_sessions = [
-        df.loc[:, ["participant_id", "session"]]
-        for df in pipelines_dict.values()
+        df.loc[:, get_id_columns(bagel)] for df in pipelines_dict.values()
     ]
 
     return all(
@@ -94,7 +102,7 @@ def get_pipelines_overview(bagel: pd.DataFrame) -> pd.DataFrame:
     (based on "pipeline_complete" column) for each participant and session.
     """
     pipeline_complete_df = bagel.pivot(
-        index=["participant_id", "session"],
+        index=get_id_columns(bagel),
         columns=["pipeline_name", "pipeline_version"],
         values="pipeline_complete",
     )

--- a/proc_dash/utility.py
+++ b/proc_dash/utility.py
@@ -44,7 +44,6 @@ def get_missing_required_columns(bagel: pd.DataFrame) -> set:
         bagel.columns
     )
 
-    # TODO: Check if there are any missing values in the `participant_id` column
     return missing_req_columns
 
 

--- a/schemas/bagel_schema.json
+++ b/schemas/bagel_schema.json
@@ -6,6 +6,12 @@
             "IsRequired": true,
             "IsPrefixedColumn": false
         },
+        "bids_id": {
+            "Description": "BIDS dataset identifier for a participant, if available/different from the participant_id.", 
+            "dtype": "str",
+            "IsRequired": false,
+            "IsPrefixedColumn": false
+        },
         "session": {
             "Description": "Participant session ID.", 
             "dtype": "str",

--- a/tests/data/example_bagel.csv
+++ b/tests/data/example_bagel.csv
@@ -1,22 +1,22 @@
-participant_id,session,has_mri_data,pipeline_name,pipeline_version,pipeline_starttime,pipeline_complete
-sub-01,1,True,freesurfer,6.0.1,2022-05-24 13:43,SUCCESS
-sub-01,2,True,freesurfer,6.0.1,2022-05-24 13:46,SUCCESS
-sub-01,3,True,freesurfer,6.0.1,UNAVAILABLE,INCOMPLETE
-sub-02,1,True,freesurfer,6.0.1,2022-05-24 14:01,SUCCESS
-sub-02,2,True,freesurfer,6.0.1,2022-05-24 16:27,SUCCESS
-sub-03,1,True,freesurfer,6.0.1,2022-05-24 17:07,FAIL
-sub-03,2,True,freesurfer,6.0.1,2022-05-24 17:06,FAIL
-sub-01,1,True,freesurfer,7.3.2,2022-09-24 13:43,SUCCESS
-sub-01,2,True,freesurfer,7.3.2,UNAVAILABLE,INCOMPLETE
-sub-01,3,False,freesurfer,7.3.2,UNAVAILABLE,INCOMPLETE
-sub-02,1,True,freesurfer,7.3.2,2022-09-24 14:01,SUCCESS
-sub-02,2,True,freesurfer,7.3.2,UNAVAILABLE,INCOMPLETE
-sub-03,1,True,freesurfer,7.3.2,2022-09-24 17:07,SUCCESS
-sub-03,2,True,freesurfer,7.3.2,UNAVAILABLE,INCOMPLETE
-sub-01,1,False,fmriprep,20.2.7,UNAVAILABLE,UNAVAILABLE
-sub-01,2,False,fmriprep,20.2.7,UNAVAILABLE,UNAVAILABLE
-sub-01,3,False,fmriprep,20.2.7,UNAVAILABLE,UNAVAILABLE
-sub-02,1,True,fmriprep,20.2.7,2022-05-24 16:26,SUCCESS
-sub-02,2,True,fmriprep,20.2.7,2022-05-24 16:26,SUCCESS
-sub-03,1,True,fmriprep,20.2.7,2022-05-24 16:26,SUCCESS
-sub-03,2,True,fmriprep,20.2.7,2022-05-24 16:33,SUCCESS
+bids_id,participant_id,session,has_mri_data,pipeline_name,pipeline_version,pipeline_starttime,pipeline_complete
+sub-mni001,sub-01,1,TRUE,freesurfer,6.0.1,2022-05-24 13:43,SUCCESS
+sub-mni001,sub-01,2,TRUE,freesurfer,6.0.1,2022-05-24 13:46,SUCCESS
+sub-mni001,sub-01,3,TRUE,freesurfer,6.0.1,UNAVAILABLE,INCOMPLETE
+sub-mni002,sub-02,1,TRUE,freesurfer,6.0.1,2022-05-24 14:01,SUCCESS
+sub-mni002,sub-02,2,TRUE,freesurfer,6.0.1,2022-05-24 16:27,SUCCESS
+sub-mni003,sub-03,1,TRUE,freesurfer,6.0.1,2022-05-24 17:07,FAIL
+sub-mni003,sub-03,2,TRUE,freesurfer,6.0.1,2022-05-24 17:06,FAIL
+sub-mni001,sub-01,1,TRUE,freesurfer,7.3.2,2022-09-24 13:43,SUCCESS
+sub-mni001,sub-01,2,TRUE,freesurfer,7.3.2,UNAVAILABLE,INCOMPLETE
+sub-mni001,sub-01,3,TRUE,freesurfer,7.3.2,UNAVAILABLE,INCOMPLETE
+sub-mni002,sub-02,1,TRUE,freesurfer,7.3.2,2022-09-24 14:01,SUCCESS
+sub-mni002,sub-02,2,TRUE,freesurfer,7.3.2,UNAVAILABLE,INCOMPLETE
+sub-mni003,sub-03,1,TRUE,freesurfer,7.3.2,2022-09-24 17:07,SUCCESS
+sub-mni003,sub-03,2,TRUE,freesurfer,7.3.2,UNAVAILABLE,INCOMPLETE
+sub-mni001,sub-01,1,TRUE,fmriprep,20.2.7,UNAVAILABLE,UNAVAILABLE
+sub-mni001,sub-01,2,TRUE,fmriprep,20.2.7,UNAVAILABLE,UNAVAILABLE
+sub-mni001,sub-01,3,TRUE,fmriprep,20.2.7,UNAVAILABLE,UNAVAILABLE
+sub-mni002,sub-02,1,TRUE,fmriprep,20.2.7,2022-05-24 16:26,SUCCESS
+sub-mni002,sub-02,2,TRUE,fmriprep,20.2.7,2022-05-24 16:26,SUCCESS
+sub-mni003,sub-03,1,TRUE,fmriprep,20.2.7,2022-05-24 16:26,SUCCESS
+sub-mni003,sub-03,2,TRUE,fmriprep,20.2.7,2022-05-24 16:33,SUCCESS


### PR DESCRIPTION
The most up-to-date bagel.csv files generated by mr_proc trackers will have an additional column `bids_id` (which will have values for subjects with BIDS imaging data) that is not currently defined in the bagel schema.

This PR adds it to the schema as an optional column and updates utility/plotting functions to handle this additional column when constructing the overview page of the dashboard.

Small changes:
- `example_bagel.csv` updated: `bids_id` col added, nonsensical `has_mri_data` statuses fixed
- Leftover TODO comment removed as it has been turned into a separate issue
- Unhandled/unexpected exceptions which are caught during a callback are now printed in the terminal for debugging purposes

Closes #24 